### PR TITLE
fix nuxt bug in docker container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,9 @@ services:
 
     networks:
       - proxy_frontend_net
+    
+    ports:
+      - 24678:24678
 
     depends_on:
       - api


### PR DESCRIPTION
### Description

Fix the bug of failed connection where nuxt keeps trying to connect to port 24678 while it's in a docker container.

### Type of change

Please select the type of change that this pull request represents:

- [ ] 💥 Breaking Change
- [ ] 🚀 Enhancement
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🏠 Internal

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
