### PR TITLE
adding plugin for socket-io

### DIFF
--- a/app/web/nuxt.config.ts
+++ b/app/web/nuxt.config.ts
@@ -2,13 +2,16 @@ import { useRuntimeConfig } from '#app'
 
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
-    runtimeConfig: {
-        public: {
-            CLIENT_ID: process.env.CLIENT_ID,
+	runtimeConfig: {
+		public: {
+			CLIENT_ID: process.env.CLIENT_ID,
             CLIENT_SECRET: process.env.CLIENT_SECRET,
             REDIRECT_URI: process.env.REDIRECT_URI,
             API_URL: process.env.API_URL,
         },
     },
     modules: ['@nuxtjs/tailwindcss'],
+	plugins: [
+		'~/plugins/socket-io.ts'
+	],
 })

--- a/app/web/pages/play.vue
+++ b/app/web/pages/play.vue
@@ -38,7 +38,11 @@ let gameSettings = ref({
     }
   }
 });
-let socket = ref(null) // socket.io
+
+const nuxtApp = useNuxtApp();
+
+const socket = nuxtApp.socket;
+
 let context = ref({})
 let player1 = ref({
   id: 1,
@@ -70,14 +74,6 @@ let player2 = ref({
 })
 
 onMounted( () => {
-  // Socket.io
-  socket.value = io("http://localhost/games", {
-    withCredentials: true,
-    extraHeaders: {
-      'Authorization': `Bearer ${useCookie('access_token').value}`
-    },
-    path: '/api/socket.io'
-  })
   socket.value.on('game_settings', (gameSettingsData) => {
     gameSettings = gameSettingsData
   })

--- a/app/web/plugins/socket-io.ts
+++ b/app/web/plugins/socket-io.ts
@@ -1,0 +1,16 @@
+import io from 'socket.io-client';
+
+import { defineNuxtPlugin } from '#app'
+
+const socket = ref();
+
+export default defineNuxtPlugin((nuxtApp) => {
+	socket.value = io("http://localhost/games", {
+		 withCredentials: true,
+		 extraHeaders: {
+		   'Authorization': `Bearer ${useCookie('access_token').value}`
+		 },
+		 path: '/api/socket.io'
+	   })
+	nuxtApp.socket = socket;
+})


### PR DESCRIPTION
### Description

I have added a socket.io-client instance to the plugin, then [attached it to the Nuxt instance as a property](https://github.com/i99dev/ft_transcendence/blob/a110813eaca768c4bd54e7d4d3e3fc2650dc915c/app/web/plugins/socket-io.ts#L15).

This will help create this instance only once and makes it available to the entire Nuxt application, which will avoid the need to create a new instance of socket.io-client in each component.

To use that instance you can easily,
Invoke the composable useNuxtApp() which will return an object to the App, and you can access the socket.io-client object from there.

Please select the type of change that this pull request represents:

- [ ] 💥 Breaking Change
- [x] 🚀 Enhancement
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🏠 Internal

## How Has This Been Tested?

A simple test by accessing the website from two different tabs and updating the player position in one tab to see if the changes were reflected in the other tab.

Just to verify if the socket is still working as previously.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
