### PR TITLE
axios removed

### DIFF
--- a/app/api/package.json
+++ b/app/api/package.json
@@ -31,6 +31,7 @@
     },
     "dependencies": {
         "@hapi/joi": "^17.1.1",
+        "@nestjs/axios": "^2.0.0",
         "@nestjs/common": "^9.3.9",
         "@nestjs/config": "^2.3.1",
         "@nestjs/core": "^9.3.9",
@@ -43,7 +44,7 @@
         "@prisma/client": "4.10.1",
         "@types/lodash": "^4.14.192",
         "@types/multer": "^1.4.7",
-        "axios": "^1.3.4",
+        "axios": "^1.3.6",
         "bcrypt": "^5.1.0",
         "chai": "^4.3.7",
         "class-transformer": "^0.5.1",
@@ -51,6 +52,7 @@
         "crypt": "^0.0.2",
         "crypto-js": "^4.1.1",
         "dotenv": "^16.0.3",
+        "esm": "^3.2.25",
         "joi": "^17.9.1",
         "lodash": "^4.17.21",
         "multer": "^1.4.5-lts.1",
@@ -104,7 +106,10 @@
             "**/*.(t|j)s"
         ],
         "coverageDirectory": "../coverage",
-        "testEnvironment": "node"
+        "testEnvironment": "node",
+        "moduleNameMapper": {
+            "axios": "./node_modules/axios/dist/node/axios.cjs"
+        }
     },
     "prisma": {
         "seed": "ts-node prisma/seed.ts"

--- a/app/api/src/auth/auth.module.ts
+++ b/app/api/src/auth/auth.module.ts
@@ -9,6 +9,7 @@ import { JwtModule } from '@nestjs/jwt'
 import { JwtStrategy } from './strategy/jwt.strategy'
 import { ConfigModule, ConfigService } from '@nestjs/config'
 import { ValidationMiddleware } from './middleware/validation.middleware'
+import { HttpModule } from '@nestjs/axios'
 
 @Module({
     imports: [
@@ -23,6 +24,7 @@ import { ValidationMiddleware } from './middleware/validation.middleware'
                 signOptions: { expiresIn: configService.getOrThrow('JWT_EXPIRES_IN') },
             }),
         }),
+        HttpModule,
     ],
     controllers: [AuthController],
     providers: [AuthService, FtStrategy, JwtStrategy, AuthRepository],

--- a/app/api/src/auth/repository/auth.repository.ts
+++ b/app/api/src/auth/repository/auth.repository.ts
@@ -1,17 +1,17 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common'
 import { intraConstants } from '../../common/constants/setting'
-import axios from 'axios'
 import { ConfigService } from '@nestjs/config'
 import { IntraAccessToken, Me } from '../interface/intra.interface'
+import { HttpService } from '@nestjs/axios'
 
 @Injectable()
 export class AuthRepository {
-    constructor(private readonly configService: ConfigService) {}
+    constructor(private readonly configService: ConfigService, private readonly httpService: HttpService) {}
 
     async getIntraAccessToken(authCode: string): Promise<IntraAccessToken> {
         try {
             return (
-                await axios.post(intraConstants.paths.token, {
+                await this.httpService.axiosRef.post(intraConstants.paths.token, {
                     grant_type: intraConstants.grant_type,
                     client_id: this.configService.getOrThrow<string>('auth.clientId'),
                     client_secret: this.configService.getOrThrow<string>('auth.clientSecret'),
@@ -27,7 +27,7 @@ export class AuthRepository {
     async getUserIntraProfile(accessToken: IntraAccessToken): Promise<Me> {
         try {
             return (
-                await axios.get(intraConstants.paths.me, {
+                await this.httpService.axiosRef.get(intraConstants.paths.me, {
                     headers: { Authorization: `Bearer ${accessToken}` },
                 })
             ).data

--- a/app/api/src/module/user/user.service.ts
+++ b/app/api/src/module/user/user.service.ts
@@ -1,6 +1,6 @@
 import { UserGetDto, UserPatchDto } from './dto/user.dto'
 import { User } from '@prisma/client'
-import { PrismaService } from '@providers/prisma/prisma.service'
+import { PrismaService } from '../../providers/prisma/prisma.service'
 import { Injectable } from '@nestjs/common'
 import { UserRepository } from './repository/user.repository'
 import { Me } from '../../auth/interface/intra.interface'

--- a/app/api/yarn.lock
+++ b/app/api/yarn.lock
@@ -695,6 +695,11 @@
     semver "^7.3.5"
     tar "^6.1.11"
 
+"@nestjs/axios@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@nestjs/axios/-/axios-2.0.0.tgz#2116fad483e232ef102a877b503a9f19926bd102"
+  integrity sha512-F6oceoQLEn031uun8NiommeMkRIojQqVryxQy/mK7fx0CI0KbgkJL3SloCQcsOD+agoEnqKJKXZpEvL6FNswJg==
+
 "@nestjs/cli@^9.3.0":
   version "9.3.0"
   resolved "https://registry.npmjs.org/@nestjs/cli/-/cli-9.3.0.tgz"
@@ -1670,10 +1675,10 @@ asynckit@^0.4.0:
   resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
-axios@^1.3.4:
-  version "1.3.4"
-  resolved "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz"
-  integrity sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==
+axios@^1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.3.6.tgz#1ace9a9fb994314b5f6327960918406fa92c6646"
+  integrity sha512-PEcdkk7JcdPiMDkvM4K6ZBRYq9keuVJsToxm2zQIM70Qqo2WHTdJZMXcG9X+RmRp2VPNUQC8W1RAGbgt6b1yMg==
   dependencies:
     follow-redirects "^1.15.0"
     form-data "^4.0.0"
@@ -2586,6 +2591,11 @@ eslint@^8.0.1:
     strip-ansi "^6.0.1"
     strip-json-comments "^3.1.0"
     text-table "^0.2.0"
+
+esm@^3.2.25:
+  version "3.2.25"
+  resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
+  integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
 
 espree@^9.4.0:
   version "9.4.1"


### PR DESCRIPTION
### Description

after the axios update, when you try to use it with jest it gives you an error while importing axios, and that’s because jest expects CJS module and axios on the old version used to emit CJS module but on the new version it is emitting ECMAScript module which causes errors for jest. and after reading the issue page, most of them didn’t work with me, but I noticed the field (moduleNameMapper) in jest conf in package.json, where I had to understand what it does, and finally I found out that you can map the import statement for axios to use a different module file that is in the format that jest can accept and work with, in brief configuring axios manually for jest so jest would be able to use axios.
the solution was to use this { “^axios$“: “axios/dist/axios.min.js” } that is a pre-bundled version of Axios that uses the CommonJS module, same axios version but using a module that jest can understand.

### Type of change

Please select the type of change that this pull request represents:

- [ ] 💥 Breaking Change
- [ ] 🚀 Enhancement
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🏠 Internal

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
