### PR TITLE
fix transition bugs

### DIFF
--- a/app/web/components/Chat/NavBar.vue
+++ b/app/web/components/Chat/NavBar.vue
@@ -29,7 +29,7 @@
                                 leave-from="translate-x-0"
                                 leave-to="translate-x-full"
                             >
-                                <DialogPanel class="pointer-events-auto w-screen max-w-md">
+                                <DialogPanel class="pointer-events-auto w-screen max-w-md z-10">
                                     <div
                                         class="flex min-h-screen flex-col bg-background shadow-xl rounded-2xl border"
                                     >

--- a/app/web/components/Friends/ListNav.vue
+++ b/app/web/components/Friends/ListNav.vue
@@ -29,7 +29,7 @@
                                 leave-from="translate-x-0"
                                 leave-to="translate-x-full"
                             >
-                                <DialogPanel class="pointer-events-auto w-screen max-w-md">
+                                <DialogPanel class="pointer-events-auto w-screen max-w-md z-10">
                                     <div
                                         class="flex min-h-screen flex-col bg-background shadow-xl rounded-2xl border"
                                     >

--- a/app/web/components/MainPopup.vue
+++ b/app/web/components/MainPopup.vue
@@ -1,5 +1,5 @@
 <template>
-    <TransitionRoot appear :show="props?.show" as="template">
+    <TransitionRoot appear :show="props?.show || false" as="template">
         <Dialog as="div" @close="$emit('closeMainPopup')" class="relative z-10">
             <TransitionChild
                 as="template"


### PR DESCRIPTION
### Description

- Fix transition error that appears in the start of the app in the case of no (seeds/empty volumes).#249
- Fix opacity bug for both chat & friends modals on frontend

### Type of change

Please select the type of change that this pull request represents:

- [ ] 💥 Breaking Change
- [ ] 🚀 Enhancement
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🏠 Internal

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
